### PR TITLE
Adding the ability to arbitrarily tag builds

### DIFF
--- a/src/zumanji/management/commands/import_performance_json.py
+++ b/src/zumanji/management/commands/import_performance_json.py
@@ -6,7 +6,7 @@ from django.db import transaction
 from django.utils import simplejson
 from django.core.management.base import BaseCommand, CommandError
 from optparse import make_option
-from zumanji.models import Project, Revision, Build, Test
+from zumanji.models import Project, Revision, Build, BuildTag, Test
 
 
 def convert_timestamp(timestamp):
@@ -173,6 +173,13 @@ class Command(BaseCommand):
 
             # Clean out old tests
             build.test_set.all().delete()
+
+            # Add tags
+            tag_list = [
+                BuildTag.objects.get_or_create(label=tag_name)[0]
+                for tag_name in data.get('tags', [])
+            ]
+            build.tags.add(*tag_list)
 
             num_tests = 0
             total_duration = 0.0

--- a/src/zumanji/migrations/0002_adding_build_tags.py
+++ b/src/zumanji/migrations/0002_adding_build_tags.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'BuildTag'
+        db.create_table('zumanji_buildtag', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('label', self.gf('django.db.models.fields.CharField')(max_length=255)),
+        ))
+        db.send_create_signal('zumanji', ['BuildTag'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'BuildTag'
+        db.delete_table('zumanji_buildtag')
+
+
+    models = {
+        'zumanji.build': {
+            'Meta': {'unique_together': "(('revision', 'datetime'),)", 'object_name': 'Build'},
+            'data': ('django.db.models.fields.TextField', [], {'default': '{}'}),
+            'datetime': ('django.db.models.fields.DateTimeField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'num_tests': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['zumanji.Project']"}),
+            'revision': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['zumanji.Revision']"}),
+            'total_duration': ('django.db.models.fields.FloatField', [], {'default': '0.0'})
+        },
+        'zumanji.buildtag': {
+            'Meta': {'object_name': 'BuildTag'},
+            'builds': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'tags'", 'symmetrical': 'False', 'to': "orm['zumanji.Build']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        'zumanji.project': {
+            'Meta': {'object_name': 'Project'},
+            'data': ('django.db.models.fields.TextField', [], {'default': '{}'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '64'})
+        },
+        'zumanji.revision': {
+            'Meta': {'unique_together': "(('project', 'label'),)", 'object_name': 'Revision'},
+            'data': ('django.db.models.fields.TextField', [], {'default': '{}'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['zumanji.Project']"})
+        },
+        'zumanji.test': {
+            'Meta': {'unique_together': "(('build', 'label'),)", 'object_name': 'Test'},
+            'build': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['zumanji.Build']"}),
+            'data': ('django.db.models.fields.TextField', [], {'default': '{}'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'lower_duration': ('django.db.models.fields.FloatField', [], {'default': '0.0'}),
+            'mean_duration': ('django.db.models.fields.FloatField', [], {'default': '0.0'}),
+            'num_tests': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['zumanji.Test']", 'null': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['zumanji.Project']"}),
+            'revision': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['zumanji.Revision']"}),
+            'upper90_duration': ('django.db.models.fields.FloatField', [], {'default': '0.0'}),
+            'upper_duration': ('django.db.models.fields.FloatField', [], {'default': '0.0'})
+        },
+        'zumanji.testdata': {
+            'Meta': {'unique_together': "(('test', 'key'),)", 'object_name': 'TestData'},
+            'build': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['zumanji.Build']"}),
+            'data': ('django.db.models.fields.TextField', [], {'default': '{}'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['zumanji.Project']"}),
+            'revision': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['zumanji.Revision']"}),
+            'test': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['zumanji.Test']"})
+        }
+    }
+
+    complete_apps = ['zumanji']

--- a/src/zumanji/templates/zumanji/build.html
+++ b/src/zumanji/templates/zumanji/build.html
@@ -4,7 +4,11 @@
   <ul class="pager">
     {% if previous_build %}
       <li class="previous">
-        <a href="{% url zumanji:view_build project_label=previous_build.project.label build_id=previous_build.id %}">&larr; Previous Build (#{{ previous_build.id }})</a>
+        {% if tag %}
+          <a href="{% url zumanji:view_build project_label=previous_build.project.label tag_id=tag.id build_id=previous_build.id %}">&larr; Previous Build (#{{ previous_build.id }})</a>
+        {% else %}
+          <a href="{% url zumanji:view_build project_label=previous_build.project.label build_id=previous_build.id %}">&larr; Previous Build (#{{ previous_build.id }})</a>
+        {% endif %}
       </li>
     {% else %}
       <li class="previous disabled">
@@ -14,7 +18,11 @@
 
     {% if next_build %}
       <li class="next">
-        <a href="{% url zumanji:view_build project_label=next_build.project.label build_id=next_build.id %}">Next Build (#{{ next_build.id }}) &rarr;</a>
+        {% if tag %}
+          <a href="{% url zumanji:view_build project_label=next_build.project.label tag_id=tag.id build_id=next_build.id %}">Next Build (#{{ next_build.id }}) &rarr;</a>
+        {% else %}
+          <a href="{% url zumanji:view_build project_label=next_build.project.label build_id=next_build.id %}">Next Build (#{{ next_build.id }}) &rarr;</a>
+        {% endif %}
       </li>
     {% else %}
       <li class="next disabled">
@@ -22,7 +30,7 @@
       </li>
     {% endif %}
   </ul>
-    
+
   <h3>Build Details</h3>
   {% include "zumanji/includes/build_details.html" %}
 

--- a/src/zumanji/templates/zumanji/includes/build_details.html
+++ b/src/zumanji/templates/zumanji/includes/build_details.html
@@ -11,4 +11,10 @@
   <dd>{{ build.num_tests }}</dd>
   <dt>Datetime</dt>
   <dd>{{ build.datetime }}</dd>
+  <dt>Tags</dt>
+  <dd>
+    {% for tag in build.tags.all %}
+      <a href="{% url zumanji:view_tag project_label=build.project.label, tag_id=tag.id %}">{{ tag.label }}</a>{% if not forloop.last %}, {% endif %}
+    {% endfor %}
+  </dd>
 </dl>

--- a/src/zumanji/templates/zumanji/tag.html
+++ b/src/zumanji/templates/zumanji/tag.html
@@ -1,14 +1,13 @@
 {% extends "zumanji/layout.html" %}
 
 {% block content %}
-  <h3>Latest Builds for {{ project.label }}</h3>
+  <h3>Latest Builds for {{ project.label }} with tag {{ tag.label }}</h3>
   <table class="table table-striped table-bordered">
     <thead>
       <tr>
         <th style="width:60px; text-align:right;">ID</th>
         <th>Revision</th>
         <th style="width:180px;">Datetime</th>
-        <th style="width:180px;">Tags</th>
         <th style="width:100px; text-align:center;">Tests</th>
         <th style="width:100px; text-align:center;">Duration</th>
       </tr>
@@ -16,14 +15,9 @@
     <tbody>
       {% for build in build_list %}
         <tr>
-          <td style="text-align:right;"><a href="{% url zumanji:view_build project_label=build.project.label, build_id=build.id %}">B{{ build.id }}</a></td>
+          <td style="text-align:right;"><a href="{% url zumanji:view_build project_label=build.project.label tag_id=tag.id build_id=build.id %}">B{{ build.id }}</a></td>
           <td>{{ build.revision.label }}</td>
           <td>{{ build.datetime }}</td>
-          <td>
-            {% for tag in build.tags.all %}
-              <a href="{% url zumanji:view_tag project_label=build.project.label, tag_id=tag.id %}">{{ tag.label }}</a>{% if not forloop.last %}, {% endif %}
-            {% endfor %}
-          </td>
           <td style="text-align:center;">{{ build.num_tests }}</td>
           <td style="text-align:center;">{{ build.total_duration|floatformat:3 }} s</td>
         </tr>

--- a/src/zumanji/urls.py
+++ b/src/zumanji/urls.py
@@ -3,6 +3,8 @@ from django.conf.urls.defaults import *
 urlpatterns = patterns('',
     url(r'^$', 'zumanji.views.index', name='index'),
     url(r'^project/(?P<project_label>[^/]+)$', 'zumanji.views.view_project', name='view_project'),
+    url(r'^project/(?P<project_label>[^/]+)/tag/(?P<tag_id>\d+)$', 'zumanji.views.view_tag', name='view_tag'),
     url(r'^project/(?P<project_label>[^/]+)/build/(?P<build_id>\d+)$', 'zumanji.views.view_build', name='view_build'),
+    url(r'^project/(?P<project_label>[^/]+)/tag/(?P<tag_id>\d+)/build/(?P<build_id>\d+)$', 'zumanji.views.view_build', name='view_build'),
     url(r'^project/(?P<project_label>[^/]+)/build/(?P<build_id>\d+)/report/(?P<test_label>[^/]+)$', 'zumanji.views.view_test', name='view_test'),
 )


### PR DESCRIPTION
This is still a WIP but wanted feedback on the direction. 

The aim of the branch is to allow categorization of builds and comparison along those categories, e.g. comparing things by branch, CI environment, database (postgres vs sqlite), etc. 
