### PR TITLE
Fixing the BuildTag migration. Cleaning tags on build reload

### DIFF
--- a/src/zumanji/management/commands/import_performance_json.py
+++ b/src/zumanji/management/commands/import_performance_json.py
@@ -174,6 +174,8 @@ class Command(BaseCommand):
             # Clean out old tests
             build.test_set.all().delete()
 
+            # Clean out old tags
+            build.tags.all().delete()
             # Add tags
             tag_list = [
                 BuildTag.objects.get_or_create(label=tag_name)[0]

--- a/src/zumanji/migrations/0002_adding_build_tags.py
+++ b/src/zumanji/migrations/0002_adding_build_tags.py
@@ -15,10 +15,21 @@ class Migration(SchemaMigration):
         ))
         db.send_create_signal('zumanji', ['BuildTag'])
 
+        # Adding M2M table for field builds on 'BuildTag'
+        db.create_table('zumanji_buildtag_builds', (
+            ('id', models.AutoField(verbose_name='ID', primary_key=True, auto_created=True)),
+            ('buildtag', models.ForeignKey(orm['zumanji.buildtag'], null=False)),
+            ('build', models.ForeignKey(orm['zumanji.build'], null=False))
+        ))
+        db.create_unique('zumanji_buildtag_builds', ['buildtag_id', 'build_id'])
+
 
     def backwards(self, orm):
         # Deleting model 'BuildTag'
         db.delete_table('zumanji_buildtag')
+
+        # Removing M2M table for field builds on 'BuildTag'
+        db.delete_table('zumanji_buildtag_builds')
 
 
     models = {

--- a/src/zumanji/models.py
+++ b/src/zumanji/models.py
@@ -103,6 +103,9 @@ class BuildTag(models.Model):
     builds = models.ManyToManyField(Build, related_name='tags')
     label = models.CharField(max_length=255)
 
+    def __unicode__(self):
+        return self.label
+
 
 class Test(models.Model):
     project = models.ForeignKey(Project)


### PR DESCRIPTION
Turns out south won't create the linker table for an M2M relationship when you use --add-model. Also fixed the lack of tag clearing when reloading a build and added a unicode method for the BuildTag model.
